### PR TITLE
feat: add support for Path & DocumentStream

### DIFF
--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -144,7 +144,7 @@ def test_load_as_markdown(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     loader = DoclingLoader(
-        file_path="https://example.com/foo.pdf",
+        source="https://example.com/foo.pdf",
         export_type=ExportType.MARKDOWN,
     )
     lc_doc_iter = loader.lazy_load()
@@ -172,7 +172,7 @@ def test_load_as_doc_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     loader = DoclingLoader(
-        file_path="https://example.com/foo.pdf",
+        source="https://example.com/foo.pdf",
         export_type=ExportType.DOC_CHUNKS,
         chunker=HierarchicalChunker(),
     )


### PR DESCRIPTION
## Background

While using `DocumentLoader` with LangChain, I noticed that although `pathlib.Path` and `docling.datamodel.base_models.DocumentStream` are supported input types in Docling, the loader here only accepted a string (representing either a file path or URL). This limitation made the integration less flexible and somewhat inconvenient.

## Changes

This PR adds support for both `DocumentStream` and `pathlib.Path` as input types, allowing `docling-langchain` to align more closely with the Docling API for document loading.

### Breaking Changes

To reflect this input change, the `file_path` parameter has been renamed to `source`, consistent with the naming used in the Docling converter interface.