### PR TITLE
fix: pin pydantic to <2.12.5 due to string constraints parameter change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ requires-python = ">=3.10,<4"  # syntax without tilde to prevent uv warning
 dependencies = [
   "langchain-core~=1.0",
   "docling~=2.26",
+  "pydantic<2.12.5",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #31

**Description:**
This PR pins `pydantic` to `<2.12.5` to resolve an import error with `StringConstraints()` that occurs when using newer versions of Pydantic with the currently stable `docling-core`.

The issue stems from a breaking change in Pydantic 2.12.5 where `StringConstraints()` no longer accepts positional arguments, which breaks `docling_core/search/package.py`. By capping the pydantic version, `langchain-docling` users will avoid this error until `docling-core` is bumped.